### PR TITLE
Add extra-libraries pgport, pgcommon, ssl and crypto

### DIFF
--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -82,12 +82,12 @@ library
       extra-libraries: libpq
 
     else
-      extra-libraries: pq
-
-      if os(openbsd)
-        extra-libraries:
-          crypto
-          ssl
+      extra-libraries:
+        pq
+        pgport
+        pgcommon
+        ssl
+        crypto
 
   -- Other-modules:
   build-tools:     hsc2hs -any


### PR DESCRIPTION
I was statically linking an application that through postgesql-libpq depended on `libpq`. And found that these external libs where missing in that scenario.

While during dynamic linking these libraries are automatically found, for static linking GHC needs to be taught about direct and indirect dependencies.

This may be a bit a controversial change as this change assumes libpq is always build against SSL. Potentially this has to be moved behind a flag. 

I'm happy to adjust this PR based on feedback.