### PR TITLE
Drop unsafe from PQconsumeInput FFI import

### DIFF
--- a/src/Database/PostgreSQL/LibPQ.hsc
+++ b/src/Database/PostgreSQL/LibPQ.hsc
@@ -2510,7 +2510,7 @@ foreign import ccall        "libpq-fe.h PQcancel"
 foreign import ccall unsafe "libpq-fe.h PQnotifies"
     c_PQnotifies :: Ptr PGconn -> IO (Ptr Notify)
 
-foreign import ccall unsafe "libpq-fe.h PQconsumeInput"
+foreign import ccall        "libpq-fe.h PQconsumeInput"
     c_PQconsumeInput :: Ptr PGconn -> IO CInt
 
 foreign import ccall unsafe "libpq-fe.h PQisBusy"


### PR DESCRIPTION
Hi @phadej!

I've been doing performance testing of [PostgREST](https://postgrest.org/en/latest) (which indirectly uses this library) with GHC 8.10.1 (and 8.8.3 too). We have a *latency spikes* issue with it, easily attributable to idle GC pauses. That is, tens-to-hundreds-of-milliseconds long stop-the-haskell-world episodes when the GC is not using the CPU; is idle; blocked.

You can check out my methods & intermediate results in this thread: https://gitlab.haskell.org/ghc/ghc/-/issues/18415

While I currently cannot *completely* explain all the idle pauses — it's 100% clear that one of contributing issues is this line here in `postgresql-libpq`. As the commit message says: `PQconsumeInput()` in libpq.so can go into blocking IO. While the [GHC User Guide][ghc-ug-ffi] isn't terribly clear on how FFI interacts with GC, you can see [this doc patch][ffi-doc-patch] and [this graph][ffi-blocked-graph]. All together, this leads to the conclusion that the import of `PQconsumeInput` *should not* be marked `unsafe`.

Sure thing, I did test this change (and not only it). It's a bit hard to summarize concisely — but if you let me hand-pick a few graphs, I'd say that this one is "typical" for the code in `master`:

![vegeta-plot-1kRPS-PQconsumeInput-unsafe](https://user-images.githubusercontent.com/365338/87152274-12034380-c2be-11ea-8a07-b0afbb685149.png)

The vertical axis is latency of PostgREST handling HTTP requests; red lines are 10s timeouts. 1000 requests-per-second load; everything run on a modest SSD laptop, without CPU saturation. Here's a similar graph for a build with this patch applied:

![vegeta-plot-1kRPS-allsafe](https://user-images.githubusercontent.com/365338/87152754-f2204f80-c2be-11ea-9786-1c8b79871021.png)

(Well actually, *all* `postgresql-libpq` imports are unmarked unsafe in the latter graph; but only `PQconsumeInput` matters.)

Might not seem significant (and I can pick way more dramatic graphs) — but when I drill down into `threadscope` profiles, this patch does eliminate places like [this][ffi-blocked-graph].

Please review, merge & release.

[ghc-ug-ffi]: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ffi-chap.html
[ffi-doc-patch]: https://github.com/ghc/ghc/pull/260/files
[ffi-blocked-graph]: https://gitlab.haskell.org/ghc/ghc/-/issues/18415#note_286630