### PR TITLE
Add `connectdbParams` and other connection key-value functions

### DIFF
--- a/postgresql-libpq.cabal
+++ b/postgresql-libpq.cabal
@@ -63,6 +63,7 @@ library
 
   other-modules:
     Database.PostgreSQL.LibPQ.Compat
+    Database.PostgreSQL.LibPQ.Connect
     Database.PostgreSQL.LibPQ.Enums
     Database.PostgreSQL.LibPQ.FFI
     Database.PostgreSQL.LibPQ.Marshal

--- a/src/Database/PostgreSQL/LibPQ/Connect.hsc
+++ b/src/Database/PostgreSQL/LibPQ/Connect.hsc
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Database.PostgreSQL.LibPQ.Connect where
+
+#include "hs-libpq.h"
+
+import Foreign (Storable (..), nullPtr)
+import Foreign.C (CInt)
+
+import qualified Data.ByteString as B
+
+-------------------------------------------------------------------------------
+-- ConninfoOption
+-------------------------------------------------------------------------------
+
+-- typedef struct
+-- {
+--     char   *keyword;   /* The keyword of the option */
+--     char   *envvar;    /* Fallback environment variable name */
+--     char   *compiled;  /* Fallback compiled in default value */
+--     char   *val;       /* Option's current value, or NULL */
+--     char   *label;     /* Label for field in connect dialog */
+--     char   *dispchar;  /* Indicates how to display this field
+--                           in a connect dialog. Values are:
+--                           ""        Display entered value as is
+--                           "*"       Password field - hide value
+--                           "D"       Debug option - don't show by default */
+--     int     dispsize;  /* Field size in characters for dialog */
+-- } PQconninfoOption;
+data ConninfoOption = ConninfoOption {
+      conninfoKeyword  :: B.ByteString -- ^ The keyword of the option
+    , conninfoEnvVar   :: Maybe B.ByteString -- ^ Fallback environment variable name
+    , conninfoCompiled :: Maybe B.ByteString -- ^ Fallback compiled in default value
+    , conninfoValue    :: Maybe B.ByteString -- ^ Option's current value, or NULL
+    , conninfoLabel    :: B.ByteString -- ^ Label for field in connect dialog
+      -- | Indicates how to display this field in a connect dialog. Values are:
+      --     ""   Display entered value as is
+      --     "*"  Password field - hide value
+      --     "D"  Debug option - don't show by default
+    , conninfoDispChar :: B.ByteString
+    , conninfoDispSize :: CInt -- ^ Field size in characters for dialog
+    }
+    deriving Show
+
+instance Storable ConninfoOption where
+  sizeOf _ = #{size PQconninfoOption}
+
+  alignment _ = #{alignment PQconninfoOption}
+
+  peek ptr = do
+      conninfoKeyword <- B.packCString =<< #{peek PQconninfoOption, keyword} ptr
+      conninfoEnvVar <- do
+        p <- #{peek PQconninfoOption, envvar} ptr
+        if p == nullPtr then pure Nothing else Just <$> B.packCString p
+      conninfoCompiled <- do
+        p <- #{peek PQconninfoOption, compiled} ptr
+        if p == nullPtr then pure Nothing else Just <$> B.packCString p
+      conninfoValue <- do
+        p <- #{peek PQconninfoOption, val} ptr
+        if p == nullPtr then pure Nothing else Just <$> B.packCString p
+      conninfoLabel <- B.packCString =<< #{peek PQconninfoOption, label} ptr
+      conninfoDispChar <- B.packCString =<< #{peek PQconninfoOption, dispchar} ptr
+      conninfoDispSize <- #{peek PQconninfoOption, dispsize} ptr
+      return $! ConninfoOption{..}
+
+  poke ptr ConninfoOption{..} = do
+      B.useAsCString conninfoKeyword $ \keyword ->
+        maybe ($ nullPtr) B.useAsCString conninfoEnvVar $ \envvar ->
+          maybe ($ nullPtr) B.useAsCString conninfoCompiled $ \compiled ->
+            maybe ($ nullPtr) B.useAsCString conninfoValue $ \value ->
+              B.useAsCString conninfoLabel $ \label ->
+                B.useAsCString conninfoDispChar $ \dispchar -> do
+                  #{poke PQconninfoOption, keyword} ptr keyword
+                  #{poke PQconninfoOption, envvar} ptr envvar
+                  #{poke PQconninfoOption, compiled} ptr compiled
+                  #{poke PQconninfoOption, val} ptr value
+                  #{poke PQconninfoOption, label} ptr label
+                  #{poke PQconninfoOption, dispchar} ptr dispchar
+                  #{poke PQconninfoOption, dispsize} ptr conninfoDispSize
+
+-------------------------------------------------------------------------------
+-- PQconninfoOption
+-------------------------------------------------------------------------------
+
+data PQconninfoOption
+
+pqConninfoOptionKeyword :: Int
+pqConninfoOptionKeyword = #{offset PQconninfoOption, keyword}

--- a/src/Database/PostgreSQL/LibPQ/FFI.hs
+++ b/src/Database/PostgreSQL/LibPQ/FFI.hs
@@ -2,11 +2,13 @@
 {-# LANGUAGE EmptyDataDecls #-}
 module Database.PostgreSQL.LibPQ.FFI where
 
-import Data.Word        (Word8)
-import Foreign.C.String (CString)
-import Foreign.C.Types  (CChar, CInt (..), CSize (..), CUInt (..))
-import Foreign.Ptr      (FunPtr, Ptr)
+import Data.Word          (Word8)
+import Foreign.C.ConstPtr (ConstPtr(..))
+import Foreign.C.String   (CString)
+import Foreign.C.Types    (CChar, CInt (..), CSize (..), CUInt (..))
+import Foreign.Ptr        (FunPtr, Ptr)
 
+import Database.PostgreSQL.LibPQ.Connect  (PQconninfoOption)
 import Database.PostgreSQL.LibPQ.Internal (CNoticeBuffer, NoticeBuffer, PGconn)
 import Database.PostgreSQL.LibPQ.Notify   (Notify, PGnotice)
 import Database.PostgreSQL.LibPQ.Oid      (Oid (..))
@@ -28,6 +30,9 @@ type NoticeReceiver = NoticeBuffer -> Ptr PGresult -> IO ()
 
 foreign import capi        "hs-libpq.h PQconnectdb"
     c_PQconnectdb :: CString -> IO (Ptr PGconn)
+
+foreign import capi        "hs-libpq.h PQconnectdbParams"
+    c_PQconnectdbParams :: ConstPtr (ConstPtr CChar) -> ConstPtr (ConstPtr CChar) -> CInt -> IO (Ptr PGconn)
 
 foreign import capi        "hs-libpq.h PQconnectStart"
     c_PQconnectStart :: CString -> IO (Ptr PGconn)
@@ -87,6 +92,18 @@ foreign import capi        "hs-libpq.h PQsocket"
 foreign import capi        "hs-libpq.h PQerrorMessage"
     c_PQerrorMessage :: Ptr PGconn -> IO CString
 
+foreign import capi        "hs-libpq.h PQconndefaults"
+    c_PQconndefaults :: IO (Ptr PQconninfoOption)
+
+foreign import capi        "hs-libpq.h PQconninfo"
+    c_PQconninfo :: Ptr PGconn -> IO (Ptr PQconninfoOption)
+
+foreign import capi        "hs-libpq.h PQconninfoParse"
+    c_PQconninfoParse :: CString -> Ptr (Ptr CChar) -> IO (Ptr PQconninfoOption)
+
+foreign import capi        "hs-libpq.h PQconninfoFree"
+    c_PQconninfoFree :: Ptr PQconninfoOption -> IO ()
+
 foreign import capi        "hs-libpq.h PQfinish"
     c_PQfinish :: Ptr PGconn -> IO ()
 
@@ -118,7 +135,7 @@ foreign import capi        "hs-libpq.h PQputCopyData"
 
 foreign import capi        "hs-libpq.h PQputCopyEnd"
     c_PQputCopyEnd :: Ptr PGconn -> CString -> IO CInt
- 
+
 -- TODO: GHC #22043
 foreign import ccall       "hs-libpq.h PQgetCopyData"
     c_PQgetCopyData :: Ptr PGconn -> Ptr (Ptr Word8) -> CInt -> IO CInt


### PR DESCRIPTION
Added a `Storable` instance for an equivalent to `PQconninfoOption` and bindings for the functions that use the struct:

  - `PQconnectdbParams`
  - `PQconndefaults`
  - `PQconninfo`
  - `PQconninfoParse`
  - `PQconninfoFree`

Also added some wrappers which do a minimum of conversion to `ByteString`s and make sure memory isn't leaked.