### PR TITLE
Add PQERRORS_SQLSTATE enum to type Verbosity

### DIFF
--- a/src/Database/PostgreSQL/LibPQ/Enums.hsc
+++ b/src/Database/PostgreSQL/LibPQ/Enums.hsc
@@ -197,12 +197,14 @@ data Verbosity
     = ErrorsTerse
     | ErrorsDefault
     | ErrorsVerbose
+    | ErrorsSqlstate
   deriving (Eq, Show)
 
 instance FromCInt Verbosity where
-    fromCInt (#const PQERRORS_TERSE)   = Just ErrorsTerse
-    fromCInt (#const PQERRORS_DEFAULT) = Just ErrorsDefault
-    fromCInt (#const PQERRORS_VERBOSE) = Just ErrorsVerbose
+    fromCInt (#const PQERRORS_TERSE)    = Just ErrorsTerse
+    fromCInt (#const PQERRORS_DEFAULT)  = Just ErrorsDefault
+    fromCInt (#const PQERRORS_VERBOSE)  = Just ErrorsVerbose
+    fromCInt (#const PQERRORS_SQLSTATE) = Just ErrorsSqlstate
     fromCInt _ = Nothing
 
 instance ToCInt Verbosity where


### PR DESCRIPTION
PostgreSQL supports `PQERRORS_SQLSTATE` (see [PGVerbosity](https://postgrespro.com/docs/postgresql/16/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY)) value for error verbosity. This is missing in the current `Verbosity` type. This is required for implementing [postgrest/#4088](https://github.com/PostgREST/postgrest/issues/4088#issue-3064260027).