### PR TITLE
Add PQERRORS_SQLSTATE enum to type Verbosity

### DIFF
--- a/src/Database/PostgreSQL/LibPQ/Enums.hsc
+++ b/src/Database/PostgreSQL/LibPQ/Enums.hsc
@@ -197,12 +197,14 @@ data Verbosity
     = ErrorsTerse
     | ErrorsDefault
     | ErrorsVerbose
+    | ErrorsSqlstate
   deriving (Eq, Show)
 
 instance FromCInt Verbosity where
-    fromCInt (#const PQERRORS_TERSE)   = Just ErrorsTerse
-    fromCInt (#const PQERRORS_DEFAULT) = Just ErrorsDefault
-    fromCInt (#const PQERRORS_VERBOSE) = Just ErrorsVerbose
+    fromCInt (#const PQERRORS_TERSE)    = Just ErrorsTerse
+    fromCInt (#const PQERRORS_DEFAULT)  = Just ErrorsDefault
+    fromCInt (#const PQERRORS_VERBOSE)  = Just ErrorsVerbose
+    fromCInt (#const PQERRORS_SQLSTATE) = Just ErrorsSqlstate
     fromCInt _ = Nothing
 
 instance ToCInt Verbosity where


### PR DESCRIPTION
Reopening this after previous unintentional merge which was reverted

PostgreSQL supports `PQERRORS_SQLSTATE` (see [PGVerbosity](https://postgrespro.com/docs/postgresql/16/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY)) value for error verbosity. This is missing in the current `Verbosity` type. This is required for implementing https://github.com/PostgREST/postgrest/issues/4088#issue-3064260027.

In `libpq` this was added in the following [commit](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=7bac3acab4d5c3f2c35aa3a7bea08411d83fd5bc) and here is the [discussion](https://www.postgresql.org/message-id/CAJRYxuKyj4zA+JGVrtx8OWAuBfE-_wN4sUMK4H49EuPed=mOBw@mail.gmail.com). I am still not sure what version of `libpq` this was released in.